### PR TITLE
Fix a bug when episode number is 0

### DIFF
--- a/sdarot-dl.py
+++ b/sdarot-dl.py
@@ -29,7 +29,7 @@ class Sdarot:
 
 		headers = Sdarot._HEADERS
 
-		if episode:
+		if episode is not None:
 			data_list = ('watch=false', 'serie=%d' % serie, 'season=%d' % season, 'episode=%d' % episode)
 		else:
 			data_list = ('episodeList=true', 'serie=%d' % serie, 'season=%d' % season)


### PR DESCRIPTION
When running
`./sdarot-dl.py 82 5 0`
you get an exception:

```
Traceback (most recent call last):
  File "/home/osmc/sdarot-dl.py", line 157, in <module>
    Sdarot.download_episode(*iargs)
  File "/home/osmc/sdarot-dl.py", line 99, in download_episode
    url = Sdarot._episode_url(epi)
  File "/home/osmc/sdarot-dl.py", line 75, in _episode_url
    if epi.has_key('error'):
AttributeError: 'list' object has no attribute 'has_key'
```

Here's a fix.
